### PR TITLE
fix(tui): prevent init crash when dashboard cell not yet registered

### DIFF
--- a/src/nbadb/cli/tui.py
+++ b/src/nbadb/cli/tui.py
@@ -38,6 +38,7 @@ from textual.widgets import (
     Sparkline,
     Static,
 )
+from textual.widgets.data_table import CellDoesNotExist
 
 from nbadb.cli._progress_common import (
     DONE_CHAR,
@@ -676,7 +677,7 @@ class NbaDbDashboard(App):
             with self.batch_update():
                 for col, val in zip(_COLUMNS, cells, strict=True):
                     table.update_cell(key, col, val)
-        except NoMatches:
+        except (NoMatches, CellDoesNotExist):
             pass
 
     # ── actions ────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Running `nbadb init` (and any other TUI-driven command like `daily`) crashes almost immediately with an unhandled `CellDoesNotExist`:

```
CellDoesNotExist: No cell exists for row_key=<...RowKey object...>, column_key=<...ColumnKey object...>.
init: stopped — progress saved in journal (resume-safe)
```

Traceback originates in `NbaDbDashboard._tick_clock` → `_update_pattern_row` → `DataTable.update_cell` (`src/nbadb/cli/tui.py`).

## Root cause

On the first `0.5s` clock tick, `_update_pattern_row` calls `DataTable.update_cell(key, col, val)` before the current pattern's row/columns are guaranteed to be registered in the table. With **textual 8.2.7** (as pinned in `uv.lock`) this raises `textual.widgets.data_table.CellDoesNotExist`.

The surrounding handler only catches `NoMatches`:

```python
except NoMatches:
    pass
```

`CellDoesNotExist` is **not** a subclass of `NoMatches` (verified: their MROs are disjoint), so the exception propagates, tears down the Textual app, and aborts the whole run. The `except NoMatches: pass` shows the intent was already to swallow missing-cell updates — it just names too narrow an exception for this version of textual.

## Fix

Catch `CellDoesNotExist` alongside `NoMatches` so a not-yet-registered cell update is skipped, matching the handler's original intent. Imported via the public `textual.widgets.data_table` path (consistent with the existing `RowKey` import in the same file).

## Impact / testing

- Non-TUI path (`--verbose`, which routes to `CIProgress`) was unaffected and already worked; this restores the default TUI path.
- `ruff check src/nbadb/cli/tui.py` passes.
- Verified the module imports cleanly and that `except (NoMatches, CellDoesNotExist)` catches the raised exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent TUI initialization and clock tick updates from crashing when attempting to update a dashboard cell that does not yet exist.